### PR TITLE
Allow users to request digest, even when no activity as occurred.

### DIFF
--- a/gravityforms-digest/gravityforms-digest.php
+++ b/gravityforms-digest/gravityforms-digest.php
@@ -27,9 +27,6 @@
 			if ( !isset( $_GET['page']) || $_GET['page'] != 'gf_edit_forms' )
 				return; // Nothing else to do, we're not on the setting page
 
-			if ( !isset( $_GET['view'] ) || ( $_GET['view'] != 'notification' && $_GET['view'] != 'settings' ) )
-				return; // Same as above, nothing to be done
-
 			add_action( 'init', array( $this, 'init' ) );
 			add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ) );
 		}


### PR DESCRIPTION
For me, the use case was:
- Client was having email issues, and distrusted the 'notifications' produced by gravity forms.
- They wanted to receive a regular digest (instead), even when there were no new leads captured.
- This is controlled via a checkbox in the digest notfication settings.

Additionally, addressed part of: https://github.com/soulseekah/Gravity-Forms-Digest-Bulk-Reports/issues/1
'Notifications digest' is now available from the main form menu
