### PR TITLE
Allow user to specify which fields get exported (+ 2 others)

### DIFF
--- a/gravityforms-digest/gravityforms-digest.php
+++ b/gravityforms-digest/gravityforms-digest.php
@@ -431,7 +431,7 @@
 					fclose( $csv );
 					$new_csv_attachment = $csv_attachment . '-' . date( 'YmdHis' ) . '.csv';
 					rename( $csv_attachment, $new_csv_attachment );
-					
+
 					wp_mail(
 						$email,
 						apply_filters(


### PR DESCRIPTION
Three updates:
- Allow user to specify which fields get exported
- Where exported field is_array() implode this field within CSV export
- Remove blank line at EOF

I realise some of the above is subjective and you would also need some new tests (I won't be offended if they don't make the cut).
:)
